### PR TITLE
hal: Restore proper ACDB loader v2 support after 21be3ac

### DIFF
--- a/hal/msm8974/platform.c
+++ b/hal/msm8974/platform.c
@@ -2132,9 +2132,9 @@ void *platform_init(struct audio_device *adev)
         }
 
         my_data->acdb_init = (acdb_init_t)dlsym(my_data->acdb_handle,
-                                                     "acdb_loader_init_v3");
+                                                     "acdb_loader_init_v2");
         if (my_data->acdb_init == NULL) {
-            ALOGE("%s: dlsym error %s for acdb_loader_init_v3", __func__, dlerror());
+            ALOGE("%s: dlsym error %s for acdb_loader_init_v2", __func__, dlerror());
             goto acdb_init_fail;
         }
 


### PR DESCRIPTION
Change-Id: I29fa8a34387ed2788b74263bae3ddf9e51c4f3ea